### PR TITLE
fix: java class parsing failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Plugin Test
         run: |
           ./gradlew :heo-gradle-plugin:publishToMavenLocal
-          ./gradlew --debug -PlocalPlugin pluginTest
+          ./gradlew -PlocalPlugin pluginTest
       - name: Create self report file
         if: success()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Plugin Test
         run: |
           ./gradlew :heo-gradle-plugin:publishToMavenLocal
-          ./gradlew -PlocalPlugin pluginTest
+          ./gradlew --debug -PlocalPlugin pluginTest
       - name: Create self report file
         if: success()
         run: |

--- a/heo-cli/src/main/java/dev/heowc/heo/cli/HeoCliService.java
+++ b/heo-cli/src/main/java/dev/heowc/heo/cli/HeoCliService.java
@@ -2,13 +2,13 @@ package dev.heowc.heo.cli;
 
 import java.util.List;
 
-import dev.heowc.heo.core.HeoException;
-
 import org.springframework.stereotype.Service;
 
+import dev.heowc.heo.core.HeoException;
 import dev.heowc.heo.core.Module;
 import dev.heowc.heo.core.analysis.application.DependencyAnalysisService;
 import dev.heowc.heo.core.analysis.domain.DependencyAnalysisResult;
+import dev.heowc.heo.core.loader.ModuleLoaderConfig;
 import dev.heowc.heo.core.loader.application.ModuleLoaderService;
 import dev.heowc.heo.core.reporting.AnalysisReportService;
 import dev.heowc.heo.core.visualization.ReportVisualizationService;
@@ -32,7 +32,7 @@ public class HeoCliService {
     }
 
     public void command(String directory, String rootPackage, String destination, HeoConfig heoConfig) {
-        final List<Module> modules = moduleLoaderService.loads(directory, rootPackage);
+        final List<Module> modules = moduleLoaderService.loads(createConfig(directory, rootPackage));
         final DependencyAnalysisResult result =
                 dependencyAnalysisService.analyzeProjectDependencies(modules, rootPackage);
         final String report = analysisReportService.createReport(result);
@@ -40,5 +40,9 @@ public class HeoCliService {
         if (heoConfig.failureOnCycles() && result.hasCycle()) {
             throw new HeoException("Cycles occurred");
         }
+    }
+
+    private static ModuleLoaderConfig createConfig(String directory, String rootPackage) {
+        return new ModuleLoaderConfig(directory, rootPackage);
     }
 }

--- a/heo-core/src/main/java/dev/heowc/heo/core/ParserConfig.java
+++ b/heo-core/src/main/java/dev/heowc/heo/core/ParserConfig.java
@@ -1,0 +1,30 @@
+package dev.heowc.heo.core;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ParserConfiguration.LanguageLevel;
+import com.github.javaparser.utils.ParserCollectionStrategy;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+class ParserConfig {
+
+    @Bean
+    ParserConfiguration parserConfiguration() {
+        final ParserConfiguration configuration = new ParserConfiguration();
+        configuration.setLanguageLevel(LanguageLevel.JAVA_17);
+        return configuration;
+    }
+
+    @Bean
+    ParserCollectionStrategy parserCollectionStrategy(ParserConfiguration parserConfiguration) {
+        return new ParserCollectionStrategy(parserConfiguration);
+    }
+
+    @Bean
+    JavaParser javaParser(ParserConfiguration parserConfiguration) {
+        return new JavaParser(parserConfiguration);
+    }
+}

--- a/heo-core/src/main/java/dev/heowc/heo/core/analysis/domain/DependencyMapper.java
+++ b/heo-core/src/main/java/dev/heowc/heo/core/analysis/domain/DependencyMapper.java
@@ -13,12 +13,13 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParseStart;
 import com.github.javaparser.Providers;
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 
@@ -28,7 +29,29 @@ import dev.heowc.heo.core.Module;
 @DomainService
 public class DependencyMapper {
 
-    private final JavaParser javaParser = new JavaParser();
+    private final Logger logger = LoggerFactory.getLogger(DependencyMapper.class);
+    private final JavaParser javaParser;
+
+    public DependencyMapper(JavaParser javaParser) {
+        this.javaParser = javaParser;
+    }
+
+    public DomainGraph mapDependencies(List<Module> modules, String rootPackage) {
+        final DomainGraph graph = new DomainGraph();
+        final GroupIdProvider groupIdProvider = new DefaultGroupIdProvider();
+        final Map<String, Module> moduleGroup = modules.stream()
+                                                       .collect(Collectors.toUnmodifiableMap(Module::getIdentity,
+                                                                                             Function.identity()));
+        final Map<String, Set<String>> result =
+                modules.stream()
+                       .map(it -> toDependentModule(rootPackage, it, moduleGroup, groupIdProvider))
+                       .peek(it -> logger.debug("module={}, dependent={}",
+                                                it.getKey(), it.getValue()))
+                       .collect(Collectors.toUnmodifiableMap(Pair::getKey, Pair::getValue, merge()));
+        graph.addVertex(result);
+        graph.addEdge(result);
+        return graph;
+    }
 
     private static String toGroupId(GroupIdProvider groupIdProvider, String rootPackage, Module module) {
         return groupIdProvider.groupId(rootPackage, module);
@@ -40,22 +63,6 @@ public class DependencyMapper {
             merged.addAll(deps2);
             return merged;
         };
-    }
-
-    public DomainGraph mapDependencies(List<Module> modules, String rootPackage) {
-        final DomainGraph graph = new DomainGraph();
-        final GroupIdProvider groupIdProvider = new DefaultGroupIdProvider();
-        final Map<String, Module> moduleGroup = modules.stream()
-                                                       .collect(Collectors.toUnmodifiableMap(Module::getIdentity,
-                                                                                             Function.identity()));
-        final Map<String, Set<String>> result = modules.stream()
-                                                       .map(it -> toDependentModule(rootPackage, it, moduleGroup,
-                                                                                    groupIdProvider))
-                                                       .collect(Collectors.toUnmodifiableMap(Pair::getKey,
-                                                                                             Pair::getValue, merge()));
-        graph.addVertex(result);
-        graph.addEdge(result);
-        return graph;
     }
 
     private Pair<String, Set<String>> toDependentModule(String rootPackage,
@@ -83,17 +90,15 @@ public class DependencyMapper {
 
     private Stream<ImportDeclaration> parseImports(Module module) {
         try {
-            final ParseResult<CompilationUnit> parsed =
-                    javaParser.parse(ParseStart.COMPILATION_UNIT,
+            final ParseResult<ImportDeclaration> parsed =
+                    javaParser.parse(ParseStart.IMPORT_DECLARATION,
                                      Providers.provider(module.getPath(),
                                                         javaParser.getParserConfiguration().getCharacterEncoding()));
 
             if (!parsed.isSuccessful()) {
                 return Stream.empty();
             }
-            return parsed.getResult().orElseThrow()
-                         .getImports()
-                         .stream();
+            return parsed.getResult().stream();
         } catch (IOException e) {
             return Stream.empty();
         }

--- a/heo-core/src/main/java/dev/heowc/heo/core/analysis/domain/DependencyMapper.java
+++ b/heo-core/src/main/java/dev/heowc/heo/core/analysis/domain/DependencyMapper.java
@@ -20,6 +20,7 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParseStart;
 import com.github.javaparser.Providers;
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 
@@ -90,15 +91,17 @@ public class DependencyMapper {
 
     private Stream<ImportDeclaration> parseImports(Module module) {
         try {
-            final ParseResult<ImportDeclaration> parsed =
-                    javaParser.parse(ParseStart.IMPORT_DECLARATION,
+            final ParseResult<CompilationUnit> parsed =
+                    javaParser.parse(ParseStart.COMPILATION_UNIT,
                                      Providers.provider(module.getPath(),
                                                         javaParser.getParserConfiguration().getCharacterEncoding()));
 
             if (!parsed.isSuccessful()) {
                 return Stream.empty();
             }
-            return parsed.getResult().stream();
+            return parsed.getResult().orElseThrow()
+                         .getImports()
+                         .stream();
         } catch (IOException e) {
             return Stream.empty();
         }

--- a/heo-core/src/main/java/dev/heowc/heo/core/loader/ModuleLoaderConfig.java
+++ b/heo-core/src/main/java/dev/heowc/heo/core/loader/ModuleLoaderConfig.java
@@ -1,0 +1,4 @@
+package dev.heowc.heo.core.loader;
+
+public record ModuleLoaderConfig(String projectDirectory, String rootPackage) {
+}

--- a/heo-core/src/main/java/dev/heowc/heo/core/loader/application/ModuleLoaderService.java
+++ b/heo-core/src/main/java/dev/heowc/heo/core/loader/application/ModuleLoaderService.java
@@ -1,19 +1,18 @@
 package dev.heowc.heo.core.loader.application;
 
-import com.github.javaparser.utils.ParserCollectionStrategy;
-
-import dev.heowc.heo.core.loader.ModuleLoaderConfig;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 
-import dev.heowc.heo.core.Module;
-import dev.heowc.heo.core.loader.domain.ModuleLoader;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import com.github.javaparser.utils.ParserCollectionStrategy;
+
+import dev.heowc.heo.core.Module;
+import dev.heowc.heo.core.loader.ModuleLoaderConfig;
+import dev.heowc.heo.core.loader.domain.ModuleLoader;
 
 @Service
 public class ModuleLoaderService {

--- a/heo-core/src/main/java/dev/heowc/heo/core/loader/application/ModuleLoaderService.java
+++ b/heo-core/src/main/java/dev/heowc/heo/core/loader/application/ModuleLoaderService.java
@@ -1,5 +1,9 @@
 package dev.heowc.heo.core.loader.application;
 
+import com.github.javaparser.utils.ParserCollectionStrategy;
+
+import dev.heowc.heo.core.loader.ModuleLoaderConfig;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -15,13 +19,18 @@ import org.springframework.stereotype.Service;
 public class ModuleLoaderService {
 
     private final Logger logger = LoggerFactory.getLogger(ModuleLoaderService.class);
+    private final ParserCollectionStrategy parserCollectionStrategy;
 
-    public List<Module> loads(String projectDirectory, String rootPackage) {
+    public ModuleLoaderService(ParserCollectionStrategy parserCollectionStrategy) {
+        this.parserCollectionStrategy = parserCollectionStrategy;
+    }
+
+    public List<Module> loads(ModuleLoaderConfig config) {
         try {
-            logger.info("Loading " + rootPackage + " from " + projectDirectory);
-            return new ModuleLoader(projectDirectory, rootPackage).loadModules();
+            logger.info("Loading " + config.rootPackage() + " from " + config.projectDirectory());
+            return new ModuleLoader(config, parserCollectionStrategy).loadModules();
         } catch (IOException e) {
-            logger.error("Error while loading " + rootPackage + " from " + projectDirectory, e);
+            logger.error("Error while loading " + config.rootPackage() + " from " + config.projectDirectory(), e);
             throw new UncheckedIOException(e);
         }
     }

--- a/heo-core/src/main/java/dev/heowc/heo/core/loader/domain/ModuleLoader.java
+++ b/heo-core/src/main/java/dev/heowc/heo/core/loader/domain/ModuleLoader.java
@@ -5,6 +5,9 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.utils.ParserCollectionStrategy;
@@ -12,9 +15,7 @@ import com.github.javaparser.utils.ProjectRoot;
 import com.github.javaparser.utils.SourceRoot;
 
 import dev.heowc.heo.core.Module;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import dev.heowc.heo.core.loader.ModuleLoaderConfig;
 
 public class ModuleLoader {
 
@@ -22,21 +23,29 @@ public class ModuleLoader {
 
     private final Path projectPath;
     private final String rootPackage;
+    private final ParserCollectionStrategy parserCollectionStrategy;
+
+    public ModuleLoader(ModuleLoaderConfig config, ParserCollectionStrategy parserCollectionStrategy) {
+        this.projectPath = Path.of(config.projectDirectory()).toAbsolutePath();
+        this.rootPackage = config.rootPackage();
+        this.parserCollectionStrategy = parserCollectionStrategy;
+    }
 
     public ModuleLoader(String projectDirectory, String rootPackage) {
-        this.projectPath = Path.of(projectDirectory).toAbsolutePath();
-        this.rootPackage = rootPackage;
+        this(new ModuleLoaderConfig(projectDirectory, rootPackage),
+             new ParserCollectionStrategy());
     }
 
     public List<Module> loadModules() throws IOException {
-        final ProjectRoot projectRoot = new ParserCollectionStrategy().collect(projectPath);
+        final ProjectRoot projectRoot = parserCollectionStrategy.collect(projectPath);
         return projectRoot.getSourceRoots()
                           .stream()
                           .filter(ModuleLoader::ignoreNonMainSourceRoot)
-                          .peek(it -> logger.info("Detected module (file://{})", it.getRoot()))
+                          .peek(it -> logger.info("Detected source (file://{})", it.getRoot()))
                           .flatMap(this::tryParseSources)
                           .filter(it -> ignoreFile(it.getStorage().orElseThrow().getPath()))
                           .map(ModuleLoader::extractModule)
+                          .peek(it -> logger.debug("Extract module ({})", it))
                           .toList();
     }
 

--- a/heo-gradle-plugin/src/main/java/dev/heowc/heo/gradle/HeoPlugin.java
+++ b/heo-gradle-plugin/src/main/java/dev/heowc/heo/gradle/HeoPlugin.java
@@ -25,7 +25,7 @@ import org.gradle.api.tasks.JavaExec;
 public class HeoPlugin implements Plugin<Project> {
 
     private static final String REPORT_PATH = "build/reports/heo";
-    private static final Pattern DOT_PATTERN = Pattern.compile(".");
+    private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
     private static final Pattern EQ_PATTERN = Pattern.compile("=");
 
     @Override
@@ -81,8 +81,8 @@ public class HeoPlugin implements Plugin<Project> {
 
     private static Map<String, String> environments(Project project, HeoPluginConfig config) {
         return logging(project, config.getLogging())
-                .map(it -> DOT_PATTERN.matcher(it).replaceAll("_"))
                 .map(String::toUpperCase)
+                .map(it -> DOT_PATTERN.matcher(it).replaceAll("_"))
                 .map(it -> {
                     final String[] keyValue = EQ_PATTERN.split(it);
                     return Map.entry(keyValue[0], keyValue[1]);
@@ -91,13 +91,13 @@ public class HeoPlugin implements Plugin<Project> {
 
     private static Stream<String> logging(Project project, @Nullable List<String> logging) {
         if (project.getGradle().getStartParameter().getLogLevel() == LogLevel.DEBUG) {
-            return Stream.of("-Dlogging.level.root=DEBUG");
+            return Stream.of("logging.level.root=DEBUG");
         }
         return Stream.ofNullable(logging)
                      .filter(Objects::nonNull)
                      .flatMap(Collection::stream)
                      .filter(Objects::nonNull)
-                     .map(it -> "-Dlogging.level." + it);
+                     .map(it -> "logging.level." + it);
     }
 
 }

--- a/heo-gradle-plugin/src/main/java/dev/heowc/heo/gradle/HeoPlugin.java
+++ b/heo-gradle-plugin/src/main/java/dev/heowc/heo/gradle/HeoPlugin.java
@@ -8,7 +8,11 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -21,6 +25,8 @@ import org.gradle.api.tasks.JavaExec;
 public class HeoPlugin implements Plugin<Project> {
 
     private static final String REPORT_PATH = "build/reports/heo";
+    private static final Pattern DOT_PATTERN = Pattern.compile(".");
+    private static final Pattern EQ_PATTERN = Pattern.compile("=");
 
     @Override
     public void apply(Project project) {
@@ -43,18 +49,16 @@ public class HeoPlugin implements Plugin<Project> {
             task.setMain("-jar");
             task.args(tempJar.getAbsolutePath());
             task.args(arguments(project, config));
-
+            task.environment(environments(project, config));
             tempJar.deleteOnExit();
         });
     }
 
-    private List<? extends Serializable> arguments(Project project, HeoPluginConfig config) {
-        return Stream.concat(Stream.of("-d", determineDirectory(project, config.getDirectoryPath()),
-                                       "-p", determinePrefixPackage(project, config.getPrefixPackage()),
-                                       "-o", determineDestination(project, config.getDestination()),
-                                       "--failure-on-cycles", String.valueOf(config.isFailureOnCycles())),
-                             logging(project, config.getLogging()))
-                     .toList();
+    private static List<? extends Serializable> arguments(Project project, HeoPluginConfig config) {
+        return List.of("-d", determineDirectory(project, config.getDirectoryPath()),
+                       "-p", determinePrefixPackage(project, config.getPrefixPackage()),
+                       "-o", determineDestination(project, config.getDestination()),
+                       "--failure-on-cycles", String.valueOf(config.isFailureOnCycles()));
     }
 
     private static String determineDirectory(Project project, @Nullable String directoryPath) {
@@ -75,7 +79,17 @@ public class HeoPlugin implements Plugin<Project> {
                : destination;
     }
 
-    private Stream<String> logging(Project project, @Nullable List<String> logging) {
+    private static Map<String, String> environments(Project project, HeoPluginConfig config) {
+        return logging(project, config.getLogging())
+                .map(it -> DOT_PATTERN.matcher(it).replaceAll("_"))
+                .map(String::toUpperCase)
+                .map(it -> {
+                    final String[] keyValue = EQ_PATTERN.split(it);
+                    return Map.entry(keyValue[0], keyValue[1]);
+                }).collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
+    }
+
+    private static Stream<String> logging(Project project, @Nullable List<String> logging) {
         if (project.getGradle().getStartParameter().getLogLevel() == LogLevel.DEBUG) {
             return Stream.of("-Dlogging.level.root=DEBUG");
         }

--- a/it/cycled-gradle-plugin/build.gradle
+++ b/it/cycled-gradle-plugin/build.gradle
@@ -29,7 +29,8 @@ if (project.hasProperty('localPlugin')) {
             var failure = false
             try {
                 tasks.heoReport.exec()
-            } catch (Exception e) {
+            } catch (Exception ignored) {
+                println("heoReport task failed")
                 failure = true
             }
             if (!failure) {

--- a/it/gradle-plugin/build.gradle
+++ b/it/gradle-plugin/build.gradle
@@ -27,6 +27,7 @@ if (project.hasProperty('localPlugin')) {
         doLast {
             try {
                 tasks.heoReport.exec()
+                println("heoReport task successful")
             } catch (Exception e) {
                 throw new IllegalStateException("The task did not succeed", e)
             }


### PR DESCRIPTION
Parsing fails for classes that use syntax provided in jdk 13 or later. This is because JavaParser supports 11 by default.

We will temporarily change this to 17, and provide a way to dynamically change the jdk version according to the project in the future.


See https://github.com/heowc/heo/issues/22